### PR TITLE
Enable sentry for knapsack servers

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,7 +5,7 @@ require 'sentry-sidekiq'
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_DSN']
   config.breadcrumbs_logger = [:active_support_logger, :http_logger, :sentry_logger]
-  # config.enabled_environments = %w[pals-knapsack-staging pals-knapsack-production]
+  config.enabled_environments = %w[palni-palci-knapsack-staging palni-palci-knapsack-production]
   # Skip Hyrax 404s
   config.excluded_exceptions += ['Hyrax::ObjectNotFoundError']
   config.debug = false


### PR DESCRIPTION
Enables sentry for the server name spaces.