### PR TITLE
Fix 'blacklight_icon' error

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -11,6 +11,7 @@ module Blacklight
     include Blacklight::RenderConstraintsHelperBehavior
     include Blacklight::RenderPartialsHelperBehavior
     include Blacklight::FacetsHelperBehavior
+    include Blacklight::IconHelperBehavior
     extend Deprecation
     self.deprecation_horizon = 'Blacklight version 7.0.0'
 


### PR DESCRIPTION
# Story

When going to the catalog search page, we were receiving error:

```
blacklight (7.35.0) app/helpers/blacklight/catalog_helper_behavior.rb:264:in `render_view_type_group_icon'
```

# Expected Behavior Before Changes
Catalog search page errors

# Expected Behavior After Changes
Catalog search page displays correctly
# Screenshots / Video

<details>
<summary>Before & After</summary>

![Screenshot 2024-05-30 at 5 59 22 PM](https://github.com/scientist-softserv/palni_palci_knapsack/assets/17851674/1de2d6c8-49a8-4795-8fb2-0ac2c954412c)

![Screenshot 2024-05-30 at 6 00 12 PM](https://github.com/scientist-softserv/palni_palci_knapsack/assets/17851674/46f152d4-5f3a-4c18-94e9-ac9fcea3c3e1)

</details>

# Notes