### PR TITLE
:bug: Remove obsolete configuration for bulkrax

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -139,11 +139,6 @@ Rails.application.config.after_initialize do
 
     # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
     # config.reserved_properties += ['my_field']
-
-    # Sidebar for hyrax 3+ support
-    if Object.const_defined?(:Hyrax) && ::Hyrax::DashboardController&.respond_to?(:sidebar_partials)
-      Hyrax::DashboardController.sidebar_partials[:repository_content] << "hyrax/dashboard/sidebar/bulkrax_sidebar_additions"
-    end
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
# Story
We are no longer on a version of Hyrax needing this config, and having it causes double sidebar entries.
Refs #41 

# Expected Behavior Before Changes

Sidebar shows Importers and Exporters links twice

# Expected Behavior After Changes

Sidebar Importers and Exporters links are not duplicated

# Screenshots / Video

<details>
<summary>Before & After</summary>

![Screenshot 2024-06-03 at 2 09 42 PM](https://github.com/scientist-softserv/palni_palci_knapsack/assets/17851674/c1b0c947-7c06-485c-aea8-2fad69007ffe)

![Screenshot 2024-06-03 at 2 09 02 PM](https://github.com/scientist-softserv/palni_palci_knapsack/assets/17851674/4ea880e6-b74e-4c9e-93f1-7e0cfcf23566)

</details>

# Notes