### PR TITLE
🐛 Fix catalog searching

### DIFF
--- a/app/helpers/hyku_knapsack/application_helper.rb
+++ b/app/helpers/hyku_knapsack/application_helper.rb
@@ -2,6 +2,8 @@
 
 module HykuKnapsack
   module ApplicationHelper
+    include Hyrax::OverrideHelperBehavior
+
     # OVERRIDE Hyrax::FileSetHelper#media_display_partial
     #
     # changed from hyrax 3.4.1 to change audio and video items to use default partial


### PR DESCRIPTION
The `#truncate_and_iconify_auto_link` method from
`Hyrax::OverrideHelperBehavior` was not being loaded.  I added an include statement to the HykuKnapsack::ApplicationHelper which solved the problem, though I thought this wasn't needed.

Ref:
  - https://github.com/scientist-softserv/palni_palci_knapsack/issues/38

![pals-38](https://github.com/scientist-softserv/palni_palci_knapsack/assets/19597776/228c4785-321c-47aa-bdad-3dd7b6af8bec)
