### PR TITLE
Update submodule

### DIFF
--- a/spec/controllers/hyrax/cdls_controller_spec.rb
+++ b/spec/controllers/hyrax/cdls_controller_spec.rb
@@ -10,7 +10,17 @@ RSpec.describe Hyrax::CdlsController do
   describe "#presenter" do
     subject { controller.send :presenter }
 
-    let(:solr_document) { SolrDocument.new(FactoryBot.create(:cdl).to_solr) }
+    let(:solr_hash) do
+      {
+        'has_model_ssim' => ['Cdl'],
+        'id' => 'abc123',
+        'title_tesim' => ['Test title']
+      }
+    end
+
+    let(:solr_document) do
+      SolrDocument.new(solr_hash)
+    end
 
     before do
       allow(controller).to receive(:search_result_document).and_return(solr_document)


### PR DESCRIPTION
# Story

## Update submodule

fb2ccd143c7d4dc9513b419457f1311c7148a338

Updating the submodule to get changes from this specific commit:
https://github.com/samvera/hyku/commit/0d1a2657329beb38a9835a8df01d00dd395612f1

Ref:
  - https://github.com/scientist-softserv/palni_palci_knapsack/issues/75

## ✅ Fix flaky spec with Advanced Search

3fed8d560f1e3a9c42129406e7d022b490ef3282

There was a flaky spec that ocurred when the CdlsController spec ran. As
far as I can tell, it was happening when a CDL factory was being
created.  I didn't chase this one down too far but the fix was making a
watered down SolrDocument instead of creating a CDL and then turning
that into a SolrDcoument.  This saves a trip to the database and makes
the spec a little faster as well.

# Expected Behavior Before Changes

A cultural heritage theme homepage crashed when having a date facet that used the blacklight_range_limit gem.  In fact the catalog page also had this problem.

# Expected Behavior After Changes

No more crashing because of the blacklight_range_limit gem.

# Screenshots / Video

<img width="576" alt="image" src="https://github.com/user-attachments/assets/1ab90c96-fb49-4fe0-a845-36fdb602ee47">
