### PR TITLE
🐛 Add terms to search fields

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -61,6 +61,7 @@ CatalogController.configure_blacklight do |config|
   config.show_fields.clear
 
   config.add_show_field solr_name("title", :stored_searchable)
+  config.add_show_field solr_name("abstract", :stored_searchable)
   config.add_show_field solr_name('admin_note', :stored_searchable), label: "Administrative Notes"
   config.add_show_field solr_name("alternative_title", :stored_searchable), label: "Alternative title"
   config.add_show_field solr_name("creator", :stored_searchable)
@@ -152,6 +153,16 @@ CatalogController.configure_blacklight do |config|
         pf: solr_name
       }
     end
+  end
+
+  config.search_fields['all_fields'].clear
+  config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false) do |field|
+    all_names = config.show_fields.values.map(&:field).join(" ")
+    title_name = 'title_tesim'
+    field.solr_parameters = {
+      qf: "#{all_names} file_format_tesim all_text_timv",
+      pf: title_name.to_s
+    }
   end
 
   # If there is something additional about a search field that needs to be customized i.e. whether to include in advanced search, or if it needs a different solr name, add it below


### PR DESCRIPTION
# Story

Prior to this commit, we didn't override the search field `all_fields` for catalog searching.  This commit will add that so metadata fields such as `abstract` can be searched for.

Ref:
  - https://github.com/scientist-softserv/palni_palci_knapsack/issues/77

# Expected Behavior Before Changes
Metadata fields such as `abstract` was no yielding search results.

# Expected Behavior After Changes
More metadata fields have been added to yield search results.

# Screenshots / Video
<img width="710" alt="image" src="https://github.com/user-attachments/assets/9054b5ff-6658-4258-a4a1-efb77b119698">

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/fe868f4a-e1eb-462a-b990-df8a91ab7cbe">
