### PR TITLE
fix-staging-solr-vars

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -179,7 +179,7 @@ extraEnvVars: &envVars
   - name: SOLR_COLLECTION_NAME
     value: palni-palci-staging
   - name: SOLR_CONFIGSET_NAME
-    value: palni-palci-staging
+    value: production-palni-palci
   - name: SOLR_HOST
     value: solr.solr
   - name: SOLR_PORT


### PR DESCRIPTION
Pals knapsack staging instance was having issues connecting to solr with several failed tenant creations. after review I noticed that:
- The password for SOLR_ADMIN_PASSWORD needed to get updated in GitHub Environments Secrets
-  The configset name needed to be changed to production-palni-palci, which was the one transferred from prod