### PR TITLE
set VALKYRIE_TRANSITION env var for staging

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -192,6 +192,8 @@ extraEnvVars: &envVars
     value: testing123
   - name: VALKYRIE_ID_TYPE
     value: string
+  - name: VALKYRIE_TRANSITION
+    value: true
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
PSD.js wasn't loading for pals knapsack staging because an env wasn't set. 🙃

Issue:
- https://github.com/scientist-softserv/palni_palci_knapsack/issues/70

# Expected Behavior Before Changes

![Screenshot 2024-08-29 at 11-34-13 Image i70-troubleshoot __ Image bc05fb4c-62ef-4f91-85dd-fb3922a8d526 __ Hyku Commons](https://github.com/user-attachments/assets/a995876b-967b-48a4-b58b-5a4ebaaa5337)


# Expected Behavior After Changes

![image](https://github.com/user-attachments/assets/0928c974-2f7b-46a0-b691-b7e4da971e0b)

