### PR TITLE
⚙️ Turn on backtrace in staging

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -118,6 +118,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: palni-palci-staging.notch8.cloud
+  - name: HYKU_SHOW_BACKTRACE
+    value: "true"
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
   - name: HYRAX_ANALYTICS


### PR DESCRIPTION
This commit will turn on backtrace in staging to help us get more information without digging through server logs.
