### PR TITLE
⚙️ Activate ReShare show theme

### DIFF
--- a/app/views/themes/reshare_show/_user_util_links.html.erb
+++ b/app/views/themes/reshare_show/_user_util_links.html.erb
@@ -1,24 +1,26 @@
-<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+<ul id="user_utility_links" class="navbar-nav ml-auto">
   <%= render 'shared/locale_picker' if available_translations.size > 1 %>
   <% if current_ability.user_groups.include?('admin') %>
-    <li>
+    <li class="nav-item">
       <%= render_notifications(user: current_user) %>
     </li>
     <li class="dropdown">
-      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false, controls: 'user-util-links' } do %>
+      <%= link_to hyrax.dashboard_profile_path(current_user), class: 'nav-link dropdown-toggle', id: 'navbarDropdown', role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false } do %>
         <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
-        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <%= current_user.name %>
         <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
-        <span class="fa fa-user" aria-hidden="true"></span>
-        <span class="caret"></span>
+        <i class="fa fa-user" aria-hidden="true"></i>
       <% end %>
-      <ul id="user-util-links" class="dropdown-menu dropdown-menu-right" role="menu">
-        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
-
-        <li class="divider"></li>
-        <li><%= link_to t("hyku.toolbar.profile.edit_registration"), main_app.edit_user_registration_path %></li>
-        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
-      </ul>
+      <div id="user-util-links" class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+        <a class="dropdown-item" href="<%= hyrax.dashboard_path %>"><%= t("hyrax.toolbar.dashboard.menu") %></a>
+	<% if Flipflop.show_login_link? || current_ability.user_groups.include?('admin') %>
+          <div class="dropdown-divider"></div>
+          <% if Devise.mappings[:user]&.registerable? %>
+            <a class="dropdown-item" href="<%= main_app.edit_user_registration_path %>"><%= t("hyku.toolbar.profile.edit_registration") %></a>
+          <% end %>
+          <a class="dropdown-item" href="<%= main_app.destroy_user_session_path %>"><%= t("hyrax.toolbar.profile.logout") %></a>
+	<% end %>
+      </div>
     </li><!-- /.btn-group -->
   <% end %>
 </ul>

--- a/config/show_themes.yml
+++ b/config/show_themes.yml
@@ -1,0 +1,19 @@
+# These settings are to provide information about your theme
+# and should follow the format
+# theme:
+#   name: Theme notes
+#   notes: Notes about the theme you want to display
+#
+default_show:
+  name: Default Show Page
+  notes: This is the default Hyku show page. It is recommended for use with cultural repositories.
+cultural_show:
+  name: Cultural Show Page
+  notes: This image based show page is recommended for cultural repositories.
+scholarly_show:
+  name: Scholarly Show Page
+  notes: This text based show page is recommended for institutional repositories.
+reshare_show:
+  name: ReShare Show Page
+  notes: For ReShare CDL Pilot use only, do not use unless instructed to do so.
+


### PR DESCRIPTION
# Story

This commit will allow users to see the reshare show theme.

# Expected Behavior Before Changes
Reshare show theme was not an option.

# Expected Behavior After Changes
Now it is.

# Screenshots / Video

<img width="1712" alt="image" src="https://github.com/user-attachments/assets/02e9cb16-05e1-4557-8bcb-8e7fa0fa0a68">

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/141074f3-a9e2-491f-b47f-04c9eb9f1ce9">
