### PR TITLE
🧹 Disable keyword as a required field

### DIFF
--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -39,7 +39,7 @@ attributes:
       - "keyword_sim"
       - "keyword_tesim"
     form:
-      required: true
+      required: false
       primary: true
     predicate: http://schema.org/keywords
   rights_statement:


### PR DESCRIPTION
Disable keyword as a required field for Generic Work to help with the migration.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/357
