### PR TITLE
🧹 Re-enable required fields for Generic Work

### DIFF
--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -26,7 +26,7 @@ attributes:
     type: string
     multiple: true
     form:
-      required: false
+      required: true
       primary: true
     index_keys:
       - "creator_sim"
@@ -46,7 +46,7 @@ attributes:
     type: string
     multiple: true
     form:
-      required: false
+      required: true
       primary: true
     index_keys:
       - "rights_statement_sim"
@@ -56,7 +56,7 @@ attributes:
     type: string
     multiple: true
     form:
-      required: false
+      required: true
       primary: true
     index_keys:
       - "resource_type_sim"


### PR DESCRIPTION
This commit will re-enable the required fields for Generic Work after Earlham and Butler migrations.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/368
