### PR TITLE
🐛 Fix unzip freezing by using system unzip

### DIFF
--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -9,3 +9,5 @@
 ensure_gem "sentry-ruby"
 ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
+
+override_gem 'willow_sword', github: 'notch8/willow_sword', branch: 'use-unzip-over-ruby-zip'


### PR DESCRIPTION
This commit will change the willow_sword to a branch that uses the system unzip command instead of the ruby zip gem since it was freezing.
