### PR TITLE
🧹 Temporarily disable keyword for generic works

### DIFF
--- a/config/metadata/generic_work_resource.yaml
+++ b/config/metadata/generic_work_resource.yaml
@@ -39,7 +39,7 @@ attributes:
       - "keyword_sim"
       - "keyword_tesim"
     form:
-      required: true
+      required: false
       primary: true
     predicate: http://schema.org/keywords
   rights_statement:


### PR DESCRIPTION
This commit will disable the keyword requirement for generic works to support migrations.
