### PR TITLE
Remove shared search from home page

### DIFF
--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -19,7 +19,8 @@
 
 <section class="product-features">
   <%# SEARCH BAR FOR HOME PAGE %>
-  <%= render partial: 'splash/search_form' %>
+  <%# Temporarily disabled - see https://github.com/notch8/palni_palci_knapsack/issues/509 %>
+  <%# render partial: 'splash/search_form' %>
   <h2>Browse our partner repositories:</h2>
   <div class="row grid-row accounts-row">
     <% @accounts.each_with_index do |account, i| %>

--- a/spec/hyku_knapsack/views/splash/index.html.erb_spec.rb
+++ b/spec/hyku_knapsack/views/splash/index.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe 'splash/index', type: :view do
+  include Warden::Test::Helpers
+  include Devise::Test::ControllerHelpers
+
+  let(:account_a) { FactoryBot.create(:account) }
+  let(:account_b) { FactoryBot.create(:account) }
+
+  before do
+    assign(:images, [])
+    assign(:accounts, [account_a, account_b])
+    view.view_paths.unshift(HykuKnapsack::Engine.root.join('app', 'views'))
+    allow(template).to receive(:render).and_call_original
+    allow(template).to receive(:render).with({ partial: "splash/search_form" }).and_return('our_search_form')
+    render
+  end
+
+  it 'renders the knapsack overlay' do
+    expect(rendered).not_to include('our_search_form')
+    expect(view.view_paths.first.path).to include('/app/samvera/app/views')
+
+    expect(rendered).to include('Collaborative Repository')
+  end
+end


### PR DESCRIPTION
Temporarily removes search partial from home page. 

This does not disable federated search if someone had the url or re-created it. 

Connected to #509 