### PR TITLE
I367 527 missing files silently fails

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "hyrax-webapp"]
 	path = hyrax-webapp
 	url = https://github.com/samvera/hyku.git
+	branch = 6.2-stable

--- a/app/jobs/bulkrax/importer_job_decorator.rb
+++ b/app/jobs/bulkrax/importer_job_decorator.rb
@@ -6,6 +6,8 @@ module Bulkrax
     def import(importer, only_updates_since_last_import)
       super
 
+      return if importer.failed?
+
       importer&.create_memberships unless importer.validate_only
     end
   end


### PR DESCRIPTION
Issue:
- https://github.com/notch8/palni_palci_knapsack/issues/367
- https://github.com/notch8/palni_palci_knapsack/issues/527

Fail the importer when any referenced file is missing, and collect all missing filenames in a single validation error instead of stopping at the first one.

This prevents silent “successful” imports and helps users fix all issues in one attempt.

# BEFORE

Failed silently. Marked import as complete but no entries were processed: 

<img width="1582" height="170" alt="image" src="https://github.com/user-attachments/assets/acc8d4af-7052-47f5-bea9-8f820089ac77" />

<img width="2704" height="2230" alt="image" src="https://github.com/user-attachments/assets/b809f106-ed56-4549-b178-e41dc91a9039" />


# AFTER

<img width="719" height="336" alt="image" src="https://github.com/user-attachments/assets/0be071b1-a701-47d0-b09e-517e5f51b795" />

<img width="720" height="333" alt="image" src="https://github.com/user-attachments/assets/b0a79b18-f0ec-45fa-b277-4c8d48568c7f" />
