### PR TITLE
🎁 Support PITT-IR's legacy URLs with redirects

### DIFF
--- a/app/controllers/hyku_knapsack/legacy_redirects_controller.rb
+++ b/app/controllers/hyku_knapsack/legacy_redirects_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Stop gap measure to redirect legacy pittir urls to their new Hyku locations
+
+module HykuKnapsack
+  class LegacyRedirectsController < ApplicationController
+    def show
+      legacy_id = params[:legacy_id]
+      solr_doc = find_work_by_legacy_id(legacy_id)
+      return raise ActionController::RoutingError, 'Not Found' if solr_doc.blank?
+
+      work_id = solr_doc['id']
+      model = solr_doc['has_model_ssim']&.first
+
+      redirect_to "/concern/#{model.tableize}/#{work_id}", status: :moved_permanently
+    end
+
+    private
+
+    def find_work_by_legacy_id(legacy_id)
+      response = Hyrax::SolrService.get("identifier_tesim:\"https://d-scholarship.pitt.edu/#{legacy_id}\"", rows: 1)
+      response.dig('response', 'docs')&.first
+    rescue RSolr::Error::Http => e
+      Rails.logger.error "Legacy ID not found: #{e.message}"
+      nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 HykuKnapsack::Engine.routes.draw do
   mount Hyrax::Engine, at: '/'
+
+  # pittir Admin Note format: /id/eprint/12345
+  get '/id/eprint/:legacy_id', to: 'legacy_redirects#show', constraints: { legacy_id: /\d+/ }
+
+  # pittir Identifier format: /12345
+  get '/:legacy_id', to: 'legacy_redirects#show', constraints: { legacy_id: /\d+/ }
 end


### PR DESCRIPTION
This commit is a stop gap measure for pittir tenant's legacy URLs.  This will allow users to go to /id/eprint/12345 or /12345 and be redirected to the correct /concern/work_types/:id URL.

![legacy_redirects](https://github.com/user-attachments/assets/463565a1-347d-4883-b191-182e0746d168)
