### PR TITLE
Overrides Hyrax's profile validator

### DIFF
--- a/app/services/hyrax/flexible_schema_validators/sort_properties_validator_decorator.rb
+++ b/app/services/hyrax/flexible_schema_validators/sort_properties_validator_decorator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Override Hyrax v5.2.0 to modify confusing error message...
+# date_ssi is loaded from created_date automatically via hyku_indexing module, but the message refers to
+# "date" property due to the date_ssi property being used in the catalog_controller's sort field.
+# To remove the misleading warning, we verify that the m3 profile actually DOES include the indexing
+# property needed.
+# This is also slightly misleading since the hyku_indexing module does the requisite indexing even if the profile doesn't explicitly include the property,
+# but this is a more accurate warning message for the user to understand.
+module Hyrax
+  module FlexibleSchemaValidators
+    module SortPropertiesValidatorDecorator
+      # Override to validate the indexing property instead of the property name.
+      def validate!
+          sort_properties.each do |property|
+          work_types_covered_by_indexing = profile['properties'].flat_map do |_prop_name, prop_config|
+            next [] unless Array(prop_config['indexing']).include?(property)
+            Array(prop_config.dig('available_on', 'class'))
+          end
+          properties_without_sort_properties = work_types_from_profile - work_types_covered_by_indexing
+          next if properties_without_sort_properties.empty?
+
+          msg = I18n.t(
+            'hyrax.flexible_schema_validators.sort_properties_validator.warnings.message',
+            property: property.sub(/_[^_]*$/, ''),
+            classes: properties_without_sort_properties.join(', ')
+          )
+          @warnings << msg
+        end
+      end
+
+      private
+
+      # Override to find the indexing property instead of the property name.
+      def find_sort_properties
+        CatalogController.blacklight_config.sort_fields.keys.filter_map do |sort_key|
+          index_field = sort_key.split.first
+          index_field unless system_properties.include?(index_field.sub(/_[^_]*$/, ''))
+        end.uniq
+      end
+    end
+  end
+end
+
+Hyrax::FlexibleSchemaValidators::SortPropertiesValidator.prepend(Hyrax::FlexibleSchemaValidators::SortPropertiesValidatorDecorator)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -69,6 +69,7 @@ properties:
     indexing:
     - title_sim
     - title_tesim
+    - title_ssi
     form:
       required: true
       primary: true
@@ -621,6 +622,7 @@ properties:
     indexing:
     - date_created_sim
     - date_created_tesim
+    - date_ssi
     form:
       primary: true
       required: true
@@ -654,6 +656,7 @@ properties:
     indexing:
     - date_created_sim
     - date_created_tesim
+    - date_ssi
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/created


### PR DESCRIPTION
# Story

Override Hyrax v5.2.0 to modify a confusing warning message.

# Details

date_ssi is loaded from created_date automatically via hyku_indexing module, but the default warning message refers to "date" property due to the date_ssi property being used in the catalog_controller's sort field.

To remove the misleading warning, we verify that the m3 profile actually DOES include the indexing property needed. This is also slightly misleading since the hyku_indexing module does the requisite indexing even if the profile doesn't explicitly include the property, but this is a more accurate warning message for the user to understand.

Additionally we add the required indexing terms to the default m3 profile even though they aren't needed for functionality.
