### PR TITLE
Increase memory for friends workers to avoid getting OOMKilled

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -208,12 +208,13 @@ extraEnvVars: &envVars
 worker:
   resources:
     limits:
-      memory: "4Gi"
+      memory: "6Gi"
       cpu: "1000m"
     requests:
-      memory: "2Gi"
+      memory: "3Gi"
       cpu: "100m"
-  replicaCount: 1
+      # temporarily increasing number of pods for large ingest
+  replicaCount: 3
   extraVolumeMounts: *volMounts
   extraEnvVars: *envVars
   podSecurityContext:


### PR DESCRIPTION
# Story
The workers on friends are currently getting OOMKilled frequently.

Temporarily increasing number of workers in config to make sure the extra pods aren't overwritten by a deploy.