### PR TITLE
Remove per-field Solr spellcheck.dictionary from catalog search fields

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -152,7 +152,8 @@ CatalogController.configure_blacklight do |config|
     config.search_fields.delete(search_field[:name])
     config.add_search_field(search_field[:name]) do |field|
       field.label = search_field[:label]
-      field.solr_parameters = { "spellcheck.dictionary": search_field[:name] }
+      # Omit spellcheck.dictionary: Hyku Solr configsets do not define per-field spellcheck
+      # dictionaries; Solr errors and Blacklight raises InvalidRequest / "don't understand" flash.
       solr_name = "#{search_field[:name]}_tesim"
       field.solr_local_parameters = {
         qf: solr_name,
@@ -200,9 +201,6 @@ CatalogController.configure_blacklight do |config|
   config.search_fields.delete('format')
   config.add_search_field('format') do |field|
     field.include_in_advanced_search = false
-    field.solr_parameters = {
-      "spellcheck.dictionary": "format"
-    }
     solr_name = 'format_tesim'
     field.solr_local_parameters = {
       qf: solr_name,

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CatalogController do
+  # Hyku Solr configsets typically omit per-field spellcheck dictionaries; sending
+  # spellcheck.dictionary=creator (etc.) causes Solr errors and Blacklight InvalidRequest.
+  describe "search field Solr params (spellcheck regression)" do
+    %w[creator keyword title contributor subject].each do |key|
+      it "does not set spellcheck.dictionary on #{key} search field" do
+        field = described_class.blacklight_config.search_fields[key]
+        expect(field).to be_present, "expected search_fields['#{key}'] to exist"
+        solr_keys = (field.solr_parameters || {}).stringify_keys.keys
+        expect(solr_keys).not_to include("spellcheck.dictionary")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ref ticket # https://github.com/notch8/palni_palci_knapsack/issues/592

Removes `spellcheck.dictionary` from Blacklight catalog search field configs so Solr is not asked for named spellcheck dictionaries that Hyku's default Solr configset does not define.

## Problem

Fielded catalog searches (e.g. work-show links with `search_field=creator` and a `q` value) sent `spellcheck.dictionary=creator` (and similar for other fields). Solr responded with errors such as "Specified dictionaries do not exist," leading to RSolr HTTP errors, `Blacklight::Exceptions::InvalidRequest`, and the "Sorry, I don't understand your search" behavior while results were wrong or unscoped.

## Solution

Drop `field.solr_parameters = { "spellcheck.dictionary": … }` from the shared catalog search fields in `hyrax-webapp/app/controllers/catalog_controller.rb` and from the knapsack `catalog_controller_decorator` loop (including `format`). Blacklight still sets `spellcheck.q` where appropriate; only the invalid per-field dictionary names are removed.

## Testing

- [ ] `/catalog?search_field=creator&q=…` (and another field, e.g. keyword) returns 200 and scoped results, no Solr spellcheck dictionary errors in logs.

## Notes

Sites that configure matching named spellcheck dictionaries in Solr can reintroduce `spellcheck.dictionary` in a local override if they want field-specific spellcheck.
