### PR TITLE
Add migration to correctly remove old field

### DIFF
--- a/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
+++ b/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # This is a duplicate of a migration added in Bulkrax in https://github.com/samvera/bulkrax/pull/1183
-# The migration is idempotent - adding it here allows us to deploy it to production more quickly. 
+# The migration is idempotent - adding it here allows us to deploy it to production more quickly.
 class RemoveParentsFromBulkraxImporterRuns < ActiveRecord::Migration[5.2]
   def up
     remove_column :bulkrax_importer_runs, :parents, if_exists: true

--- a/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
+++ b/db/migrate/20260424081537_remove_parents_from_bulkrax_importer_runs.rb
@@ -1,0 +1,11 @@
+# This is a duplicate of a migration added in Bulkrax in https://github.com/samvera/bulkrax/pull/1183
+# The migration is idempotent - adding it here allows us to deploy it to production more quickly. 
+class RemoveParentsFromBulkraxImporterRuns < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :bulkrax_importer_runs, :parents, if_exists: true
+  end
+
+  def down
+    add_column :bulkrax_importer_runs, :parents, :text, array: true, default: "{}", unless_exists: true
+  end
+end


### PR DESCRIPTION
Previously improperly removed by removing a migration, rather than adding a new migration to remove it. 

This migration has also been added to Bulkrax. It is idempotent, it is being added here so it can be rolled out more quickly.

Connected to #590