### PR TITLE
WIP: enables chunk uploads for willow_sword

### DIFF
--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -11,4 +11,5 @@ ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
 override_gem "willow_sword",
   github: "notch8/willow_sword",
-  ref: "e7f88deb225eaca769aace035c42504d9a34d372"
+  ref: "562cd9795ef716b30f7450b07147177b63e4205a"
+  

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -11,5 +11,5 @@ ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
 override_gem "willow_sword",
   github: "notch8/willow_sword",
-  ref: "12199c22e963911e2aeb0f1034002de8e8660154"
+  ref: "f86d8f58ef487144e533ac68ca2f6958681a2b0c"
   

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -11,5 +11,5 @@ ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
 override_gem "willow_sword",
   github: "notch8/willow_sword",
-  ref: "c11d4f7a2fc85678c1741e1e6f87727ab51e62f8"
+  ref: "12199c22e963911e2aeb0f1034002de8e8660154"
   

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -9,3 +9,6 @@
 ensure_gem "sentry-ruby"
 ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
+override_gem "willow_sword",
+  github: "notch8/willow_sword",
+  ref: "e7f88deb225eaca769aace035c42504d9a34d372"

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -11,5 +11,5 @@ ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
 override_gem "willow_sword",
   github: "notch8/willow_sword",
-  ref: "562cd9795ef716b30f7450b07147177b63e4205a"
+  ref: "c11d4f7a2fc85678c1741e1e6f87727ab51e62f8"
   

--- a/bundler.d/example.rb
+++ b/bundler.d/example.rb
@@ -11,5 +11,4 @@ ensure_gem "sentry-rails"
 ensure_gem "cancancan", "~> 3.0" # cancancan is bundling to v1.17.0 but we need at least 3.0
 override_gem "willow_sword",
   github: "notch8/willow_sword",
-  ref: "f86d8f58ef487144e533ac68ca2f6958681a2b0c"
-  
+  ref: "2bdd6b5c1ef4fd6b04ce9e5cf462b46be8f580b1"


### PR DESCRIPTION
points to willow_sword i540-chunked-uploads-willow-sword

# Story

Refs 
- #617, 
- #540

# Expected Behavior Before Changes

- A **single** SWORD `POST` of a large package (for example **>~100 MB** in one request to `.../collections/:id/works`) can fail with **HTTP 413** at **Cloudflare** (or another edge) before the app runs, so the deposit never completes.
- There is **no** SWORD v2 **staged upload** API: no `POST /sword/v2/uploads`, no `PUT` chunks with `Content-Range`, and no work create with **`Upload-References`** to attach a pre-uploaded file to the same deposit path as today.

# Expected Behavior After Changes

- **Staged SWORD v2 upload** is available: **initiate** upload, send the package in **one or more** `PUT` requests (each at or under **`max_chunk_size`**, default **90 MiB**), then **create a work** with a **small** `POST` and header **`Upload-References: <upload-uuid>`** plus metadata XML. The same bag or zip pipeline runs after assembly.
- **Unchanged** default: deposits **without** `Upload-References` still use the existing **single** `POST` to `.../works` when the package fits per-request limits.
- **Config** and **cleanup** of stale staged files on shared disk (for example `tmp/network_files/willow_sword` on Hyku) with a **CleanupStaleUploadsJob** where wired in the host app.


# Notes

- **Cloudflare 413** is a **per-request** limit on the **hostname**; it is not fixed by an app route tweak. Staged upload keeps each request under the cap while the **assembled** file can still be large (up to **`max_total_upload_size`**, default **2 GiB** in gem defaults).
- **Multi-step on the wire** is required for this design; give integrators a **script** or document the HTTP sequence (see `documentation/sword-staged-upload-verification.md` in the knapsack repo).
- **Willow Sword** implementation: [notch8/willow_sword#59](https://github.com/notch8/willow_sword/pull/59) 