### PR TITLE
Default to 3 Solr collection replicas

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -196,6 +196,8 @@ extraEnvVars: &envVars
     value: admin
   - name: SOLR_COLLECTION_NAME
     value: palni-palci-knapsack-friends
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "3"
   - name: SOLR_CONFIGSET_NAME
     # do not change this value
     value: production-palni-palci

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -218,6 +218,8 @@ extraEnvVars: &envVars
     value: admin
   - name: SOLR_COLLECTION_NAME
     value: production-palni-palci
+  - name: SOLR_COLLECTION_REPLICAS
+    value: "3"
   - name: SOLR_CONFIGSET_NAME
     value: production-palni-palci
   - name: SOLR_HOST


### PR DESCRIPTION
We are now running on 3 Solr pods on both staging and production, which should help stability, availability, and performance. One replica per pod.
