### PR TITLE
Add test subdomain for sword uploads for pitt

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -399,6 +399,15 @@ extraDeploy:
               {{- toYaml . | nindent 8 }}
             {{- end }}
   - |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{ include "hyrax.fullname" . }}-sword-proxy-headers
+        labels:
+          {{- include "hyrax.labels" . | nindent 4 }}
+      data:
+        Host: pittir-staging.hykucommons.org
+  - |-
       apiVersion: networking.k8s.io/v1
       kind: Ingress
       metadata:
@@ -408,7 +417,7 @@ extraDeploy:
         annotations:
           nginx.org/client-max-body-size: "0"
           cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
-          nginx.org/location-snippets: "proxy_set_header Host pittir-staging.hykucommons.org;"
+          nginx.org/proxy-set-headers: "{{ .Release.Namespace }}/{{ include "hyrax.fullname" . }}-sword-proxy-headers"
       spec:
         ingressClassName: nginx-ingress
         tls:

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -61,6 +61,11 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+      # Non-proxied subdomain for SWORD uploads - bypasses Cloudflare size limits
+    - host: sword.pittir-staging.hykucommons.org
+      paths:
+        - path: /sword
+          pathType: Prefix
   annotations:
     nginx.org/client-max-body-size: "0"
     cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
@@ -73,6 +78,10 @@ ingress:
     - hosts:
         - pittir-staging.hykucommons.org
       secretName: pittir-staging-hykucommons-tls
+      # Non-proxied subdomain for SWORD uploads
+    - hosts:
+        - sword.pittir-staging.hykucommons.org
+      secretName: sword-pittir-staging-hykucommons-tls
 
 extraEnvVars: &envVars
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -399,42 +399,31 @@ extraDeploy:
               {{- toYaml . | nindent 8 }}
             {{- end }}
   - |-
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: {{ include "hyrax.fullname" . }}-sword-proxy-headers
-        labels:
-          {{- include "hyrax.labels" . | nindent 4 }}
-      data:
-        Host: pittir-staging.hykucommons.org
-  - |-
-      apiVersion: networking.k8s.io/v1
-      kind: Ingress
+      apiVersion: k8s.nginx.org/v1
+      kind: VirtualServer
       metadata:
         name: {{ include "hyrax.fullname" . }}-sword
         labels:
           {{- include "hyrax.labels" . | nindent 4 }}
-        annotations:
-          nginx.org/client-max-body-size: "0"
-          cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
-          nginx.org/proxy-set-headers: "{{ .Release.Namespace }}/{{ include "hyrax.fullname" . }}-sword-proxy-headers"
       spec:
-        ingressClassName: nginx-ingress
+        host: sword.pittir-staging.hykucommons.org
         tls:
-          - hosts:
-              - sword.pittir-staging.hykucommons.org
-            secretName: sword-pittir-staging-hykucommons-tls
-        rules:
-          - host: sword.pittir-staging.hykucommons.org
-            http:
-              paths:
-                - path: /sword
-                  pathType: Prefix
-                  backend:
-                    service:
-                      name: {{ include "hyrax.fullname" . }}
-                      port:
-                        number: 80
+          secret: sword-pittir-staging-hykucommons-tls
+          redirect:
+            enable: true
+        upstreams:
+          - name: app
+            service: {{ include "hyrax.fullname" . }}
+            port: 80
+        routes:
+          - path: /sword
+            action:
+              proxy:
+                upstream: app
+                requestHeaders:
+                  set:
+                    - name: Host
+                      value: pittir-staging.hykucommons.org
 
 embargoRelease:
   enabled: false

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -424,6 +424,8 @@ extraDeploy:
                   set:
                     - name: Host
                       value: pittir-staging.hykucommons.org
+                    - name: X-Forwarded-Host
+                      value: pittir-staging.hykucommons.org
 
 embargoRelease:
   enabled: false

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -61,11 +61,6 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-      # Non-proxied subdomain for SWORD uploads - bypasses Cloudflare size limits
-    - host: sword.pittir-staging.hykucommons.org
-      paths:
-        - path: /sword
-          pathType: Prefix
   annotations:
     nginx.org/client-max-body-size: "0"
     cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
@@ -78,10 +73,6 @@ ingress:
     - hosts:
         - pittir-staging.hykucommons.org
       secretName: pittir-staging-hykucommons-tls
-      # Non-proxied subdomain for SWORD uploads
-    - hosts:
-        - sword.pittir-staging.hykucommons.org
-      secretName: sword-pittir-staging-hykucommons-tls
 
 extraEnvVars: &envVars
   - name: BUNDLE_DISABLE_LOCAL_BRANCH_CHECK
@@ -407,6 +398,34 @@ extraDeploy:
             tolerations:
               {{- toYaml . | nindent 8 }}
             {{- end }}
+  - |-
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: {{ include "hyrax.fullname" . }}-sword
+        labels:
+          {{- include "hyrax.labels" . | nindent 4 }}
+        annotations:
+          nginx.org/client-max-body-size: "0"
+          cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
+          nginx.org/location-snippets: "proxy_set_header Host pittir-staging.hykucommons.org;"
+      spec:
+        ingressClassName: nginx-ingress
+        tls:
+          - hosts:
+              - sword.pittir-staging.hykucommons.org
+            secretName: sword-pittir-staging-hykucommons-tls
+        rules:
+          - host: sword.pittir-staging.hykucommons.org
+            http:
+              paths:
+                - path: /sword
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: {{ include "hyrax.fullname" . }}
+                      port:
+                        number: 80
 
 embargoRelease:
   enabled: false


### PR DESCRIPTION
# Story
Large uploads are failing via Sword because of Cloudflare limits on proxied domains. We want to keep the overall application behind the proxy in order to protect it; however, we want to make it so the `/sword` endpoint is not proxied, so we can do large uploads without chunking.

Connected to #540 

# Expected Behavior Before Changes
Large uploads to https://pittir-staging.hykucommons.org/sword hit Cloudflare limits

# Expected Behavior After Changes
Large uploads to https://sword.pittir-staging.hykucommons.org/sword do not hit Cloudflare limits, since it is not proxied. No other paths of the application are not reachable at https://sword.pittir-staging.hykucommons.org/

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes