### PR TITLE
Increase timeout for staging fcrepo for cleaner startup

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -435,6 +435,12 @@ fcrepo:
       database: fcrepo
     containerPorts:
       postgresql: 5432
+  livenessProbe:
+    initialDelaySeconds: 90
+    failureThreshold: 6
+  readinessProbe:
+    initialDelaySeconds: 90
+    failureThreshold: 6
   s3:
     enabled: true
     bucket: besties-fcrepo-clone


### PR DESCRIPTION
The friends deployment was failing when the fcrepo configuration was changed because it didn't have enough time configured for the liveness and readiness probes.

This is already live, this persists it across deploys.