### PR TITLE
Serve static files via nginx

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -27,7 +27,7 @@ jobs:
     uses: notch8/actions/.github/workflows/build.yaml@v1.0.10
     secrets: inherit
     with:
-      components: '["web","worker","solr"]'
+      components: '["web","worker","solr","nginx"]'
 
   test:
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,15 @@ CMD ./bin/web
 FROM hyku-web AS hyku-worker
 CMD ./bin/worker
 
+FROM registry.gitlab.com/notch8/scripts/bitnami-nginx:1.21.5-debian-10-r4 AS hyku-nginx
+# Bake this exact commit's compiled assets/vendored viewer libs into the nginx
+# image itself, so nginx and Rails always agree on what a deploy's asset URLs
+# resolve to - no shared volume, no deploy-time copy step, no accumulation to
+# prune (old versions just age out of the image registry like any other tag).
+COPY --from=hyku-web /app/samvera/hyrax-webapp/public/assets /app/samvera/hyrax-webapp/public/assets
+COPY --from=hyku-web /app/samvera/hyrax-webapp/public/pdf.js /app/samvera/hyrax-webapp/public/pdf.js
+COPY --from=hyku-web /app/samvera/hyrax-webapp/public/uv /app/samvera/hyrax-webapp/public/uv
+
 # Use a Solr version with patched Log4j to address CVE-2021-44228
 FROM solr:8.11.2 AS hyku-solr
 ENV SOLR_USER="solr" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,7 @@ FROM hyku-web AS hyku-worker
 CMD ./bin/worker
 
 FROM registry.gitlab.com/notch8/scripts/bitnami-nginx:1.21.5-debian-10-r4 AS hyku-nginx
-# Bake this exact commit's compiled assets/vendored viewer libs into the nginx
-# image itself, so nginx and Rails always agree on what a deploy's asset URLs
-# resolve to - no shared volume, no deploy-time copy step, no accumulation to
-# prune (old versions just age out of the image registry like any other tag).
+# Copy assets & other public files into nginx so it can serve them as static files
 COPY --from=hyku-web /app/samvera/hyrax-webapp/public/assets /app/samvera/hyrax-webapp/public/assets
 COPY --from=hyku-web /app/samvera/hyrax-webapp/public/pdf.js /app/samvera/hyrax-webapp/public/pdf.js
 COPY --from=hyku-web /app/samvera/hyrax-webapp/public/uv /app/samvera/hyrax-webapp/public/uv

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -536,7 +536,7 @@ nginx:
     # no-op for every other request.
     map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
         default upgrade;
-        ''      close;
+        ''      '';
     }
 
     log_format loki 'host=${DOLLAR}host ip=${DOLLAR}http_x_forwarded_for remote_user=${DOLLAR}remote_user [${DOLLAR}time_local] '

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -453,6 +453,10 @@ global:
       username: fcrepo
       password: $DB_PASSWORD
       postgresPassword: $DB_PASSWORD
+  # Required for the nginx serverBlock's `upstream rails_app` to resolve --
+  # friends' actual Rails Service name (unlike production's, which has no
+  # -hyrax suffix).
+  hyraxHostName: palni-palci-knapsack-friends-hyrax
 postgresql:
   enabled: false
 redis:
@@ -502,6 +506,134 @@ externalSolrCollection: "palni-palci-knapsack-friends"
 externalSolrPassword: $SOLR_ADMIN_PASSWORD
 
 nginx:
-  enabled: false
+  # Step 1 (bug repro) was: enabled, no extraVolumes/extraVolumeMounts,
+  # matching production's current broken no-op passthrough config -- see
+  # hykuup_knapsack/timeout_notes.md and pals-stress-tests' README for that
+  # baseline. This is step 3, the real fix: mount the existing `uploads` PVC's
+  # public-system subPath so nginx can actually serve /system/* itself,
+  # matching the already-validated HykuUp pattern. Deliberately NOT widening
+  # this to public/uploads -- see the still-open safety question in
+  # timeout_notes.md about that path's permission model.
+  enabled: true
   service:
-    port: 80
+    type: ClusterIP
+  image:
+    registry: registry.gitlab.com
+    repository: notch8/scripts/bitnami-nginx
+    tag: 1.21.5-debian-10-r4
+  extraVolumes:
+    - name: uploads
+      persistentVolumeClaim:
+        claimName: "{{ .Values.global.hyraxHostName }}-uploads"
+  extraVolumeMounts:
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/system
+      subPath: public-system
+  serverBlock: |-
+    upstream rails_app {
+      server {{ .Values.global.hyraxHostName }};
+    }
+
+    map ${DOLLAR}status ${DOLLAR}loggable {
+        ~^444  0;
+        default 1;
+    }
+
+    log_format loki 'host=${DOLLAR}host ip=${DOLLAR}http_x_forwarded_for remote_user=${DOLLAR}remote_user [${DOLLAR}time_local] '
+                      'request="${DOLLAR}request" status=${DOLLAR}status bytes=${DOLLAR}body_bytes_sent '
+                      'referer="${DOLLAR}http_referer" agent="${DOLLAR}http_user_agent" request_time=${DOLLAR}request_time upstream_response_time=${DOLLAR}upstream_response_time upstream_response_length=${DOLLAR}upstream_response_length';
+
+    error_log  /opt/bitnami/nginx/logs/error.log warn;
+    #tcp_nopush     on;
+
+    # Cloudflare ips see for refresh
+    # https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-logging-visitor-IP-addresses
+    # update list https://www.cloudflare.com/ips/
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 2c0f:f248::/32;
+
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+    include /opt/bitnami/nginx/conf/conf.d/*.conf;
+    server {
+        listen 8080;
+        server_name _;
+        root /app/samvera/hyrax-webapp/public;
+        index index.html;
+
+        client_body_in_file_only clean;
+        client_body_buffer_size 32K;
+        client_max_body_size 0;
+        access_log /opt/bitnami/nginx/logs/access.log loki;
+        # if=${DOLLAR}loggable;
+
+        sendfile on;
+        send_timeout 300s;
+
+        include /opt/bitnami/nginx/conf/bots.d/ddos.conf;
+        include /opt/bitnami/nginx/conf/bots.d/blockbots.conf;
+
+        location ~ (\.php|\.aspx|\.asp) {
+        	return 404;
+        }
+
+        # deny requests for files that should never be accessed
+        location ~ /\. {
+          deny all;
+        }
+
+        location ~* ^.+\.(rb|log)${DOLLAR} {
+          deny all;
+        }
+
+        # serve static (compiled) assets directly if they exist (for rails production)
+        location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system)/ {
+          try_files ${DOLLAR}uri @rails;
+
+          # access_log off;
+          gzip_static on; # to serve pre-gzipped version
+
+          expires max;
+          add_header Cache-Control public;
+
+          # Some browsers still send conditional-GET requests if there's a
+          # Last-Modified header or an ETag header even if they haven't
+          # reached the expiry date sent in the Expires header.
+          add_header Last-Modified "";
+          add_header ETag "";
+          break;
+        }
+
+        # send non-static file requests to the app server
+        location / {
+          try_files ${DOLLAR}uri @rails;
+        }
+
+        location @rails {
+          proxy_set_header  X-Real-IP  ${DOLLAR}remote_addr;
+          proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+          proxy_set_header Host ${DOLLAR}http_host;
+          proxy_redirect off;
+          proxy_pass http://rails_app;
+        }
+    }

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -1,12 +1,19 @@
 replicaCount: 2
 
 resources:
+  # CPU bumped per calculate_limits_and_requests' r2-friends right-sizing
+  # report (2026-07-28): p95=597-655m, p99=690-748m against the old 1000m
+  # limit -- also independently confirmed via pals-stress-tests' before/after
+  # runs, which measured real CPU throttling (~29-38% of periods, both
+  # before and after the nginx fix) at the old limit. Memory left unchanged
+  # -- p99 usage was ~869-895Mi against this same 4Gi, no need there, and
+  # this cluster's nodes are memory- not CPU-constrained.
   limits:
     memory: "4Gi"
-    cpu: "1000m"
+    cpu: "1250m"
   requests:
     memory: "2Gi"
-    cpu: "300m"
+    cpu: "900m"
 
 livenessProbe:
   enabled: false

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -553,6 +553,16 @@ nginx:
         default 1;
     }
 
+    # Lets the ActionCable websocket handshake for Hyrax's realtime
+    # notifications (/notifications/endpoint) actually upgrade instead of
+    # silently falling through to a plain HTTP request that Rails 404s --
+    # only kicks in when the client sends an Upgrade header, so it's a
+    # no-op for every other request.
+    map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     log_format loki 'host=${DOLLAR}host ip=${DOLLAR}http_x_forwarded_for remote_user=${DOLLAR}remote_user [${DOLLAR}time_local] '
                       'request="${DOLLAR}request" status=${DOLLAR}status bytes=${DOLLAR}body_bytes_sent '
                       'referer="${DOLLAR}http_referer" agent="${DOLLAR}http_user_agent" request_time=${DOLLAR}request_time upstream_response_time=${DOLLAR}upstream_response_time upstream_response_length=${DOLLAR}upstream_response_length';
@@ -652,6 +662,9 @@ nginx:
           proxy_set_header  X-Real-IP  ${DOLLAR}remote_addr;
           proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
           proxy_set_header Host ${DOLLAR}http_host;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade ${DOLLAR}http_upgrade;
+          proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
           proxy_pass http://rails_app;
         }

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -516,18 +516,25 @@ nginx:
   # Step 1 (bug repro) was: enabled, no extraVolumes/extraVolumeMounts,
   # matching production's current broken no-op passthrough config -- see
   # hykuup_knapsack/timeout_notes.md and pals-stress-tests' README for that
-  # baseline. This is step 3, the real fix: mount the existing `uploads` PVC's
-  # public-system subPath so nginx can actually serve /system/* itself,
-  # matching the already-validated HykuUp pattern. Deliberately NOT widening
-  # this to public/uploads -- see the still-open safety question in
-  # timeout_notes.md about that path's permission model.
+  # baseline. Step 3 (the /system/* fix) mounted the existing `uploads` PVC's
+  # public-system subPath. This is step 3b: real user traffic showed
+  # /assets/* (fonts/css/js -- far higher volume than the one tenant logo)
+  # was STILL 100% proxied to Puma (18s+ responses seen live), because
+  # public/assets doesn't exist on the nginx pod at all -- it's baked into
+  # the *web* image at build time, not on any EFS volume, and this generic
+  # bitnami-nginx image has no copy of it. Fixed the same way HykuUp already
+  # does it: a dedicated `hyku-nginx` Dockerfile stage bakes public/assets,
+  # public/pdf.js, and public/uv into the nginx image itself from the exact
+  # same commit as the web image -- no shared volume, no deploy-time copy
+  # step needed for these three. public/system stays on the EFS mount below
+  # since that's genuinely runtime-uploaded content, not image-baked.
   enabled: true
   service:
     type: ClusterIP
   image:
-    registry: registry.gitlab.com
-    repository: notch8/scripts/bitnami-nginx
-    tag: 1.21.5-debian-10-r4
+    registry: ghcr.io
+    repository: "$REPO_LOWER/nginx"
+    tag: "$TAG"
   extraVolumes:
     - name: uploads
       persistentVolumeClaim:
@@ -614,7 +621,12 @@ nginx:
         }
 
         # serve static (compiled) assets directly if they exist (for rails production)
-        location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system)/ {
+        # uv/pdf.js added -- now baked into the nginx image itself (see the
+        # hyku-nginx Dockerfile stage), matching HykuUp's pattern. `branding`
+        # deliberately left out: PALs' public/branding is a symlink to
+        # /app/samvera/branding, a separate chart-templated PVC mechanism
+        # this change doesn't touch -- not investigated, not in scope here.
+        location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system|uv|pdf\.js)/ {
           try_files ${DOLLAR}uri @rails;
 
           # access_log off;

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -1,13 +1,6 @@
 replicaCount: 2
 
 resources:
-  # CPU bumped per calculate_limits_and_requests' r2-friends right-sizing
-  # report (2026-07-28): p95=597-655m, p99=690-748m against the old 1000m
-  # limit -- also independently confirmed via pals-stress-tests' before/after
-  # runs, which measured real CPU throttling (~29-38% of periods, both
-  # before and after the nginx fix) at the old limit. Memory left unchanged
-  # -- p99 usage was ~869-895Mi against this same 4Gi, no need there, and
-  # this cluster's nodes are memory- not CPU-constrained.
   limits:
     memory: "4Gi"
     cpu: "1250m"
@@ -460,9 +453,7 @@ global:
       username: fcrepo
       password: $DB_PASSWORD
       postgresPassword: $DB_PASSWORD
-  # Required for the nginx serverBlock's `upstream rails_app` to resolve --
-  # friends' actual Rails Service name (unlike production's, which has no
-  # -hyrax suffix).
+  # Required for the nginx serverBlock's `upstream rails_app` to resolve
   hyraxHostName: palni-palci-knapsack-friends-hyrax
 postgresql:
   enabled: false
@@ -513,21 +504,6 @@ externalSolrCollection: "palni-palci-knapsack-friends"
 externalSolrPassword: $SOLR_ADMIN_PASSWORD
 
 nginx:
-  # Step 1 (bug repro) was: enabled, no extraVolumes/extraVolumeMounts,
-  # matching production's current broken no-op passthrough config -- see
-  # hykuup_knapsack/timeout_notes.md and pals-stress-tests' README for that
-  # baseline. Step 3 (the /system/* fix) mounted the existing `uploads` PVC's
-  # public-system subPath. This is step 3b: real user traffic showed
-  # /assets/* (fonts/css/js -- far higher volume than the one tenant logo)
-  # was STILL 100% proxied to Puma (18s+ responses seen live), because
-  # public/assets doesn't exist on the nginx pod at all -- it's baked into
-  # the *web* image at build time, not on any EFS volume, and this generic
-  # bitnami-nginx image has no copy of it. Fixed the same way HykuUp already
-  # does it: a dedicated `hyku-nginx` Dockerfile stage bakes public/assets,
-  # public/pdf.js, and public/uv into the nginx image itself from the exact
-  # same commit as the web image -- no shared volume, no deploy-time copy
-  # step needed for these three. public/system stays on the EFS mount below
-  # since that's genuinely runtime-uploaded content, not image-baked.
   enabled: true
   service:
     type: ClusterIP
@@ -630,12 +606,6 @@ nginx:
           deny all;
         }
 
-        # serve static (compiled) assets directly if they exist (for rails production)
-        # uv/pdf.js added -- now baked into the nginx image itself (see the
-        # hyku-nginx Dockerfile stage), matching HykuUp's pattern. `branding`
-        # deliberately left out: PALs' public/branding is a symlink to
-        # /app/samvera/branding, a separate chart-templated PVC mechanism
-        # this change doesn't touch -- not investigated, not in scope here.
         location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system|uv|pdf\.js)/ {
           try_files ${DOLLAR}uri @rails;
 

--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -435,6 +435,12 @@ fcrepo:
       database: fcrepo
     containerPorts:
       postgresql: 5432
+  livenessProbe:
+    initialDelaySeconds: 90
+    failureThreshold: 6
+  readinessProbe:
+    initialDelaySeconds: 90
+    failureThreshold: 6
   s3:
     enabled: true
     bucket: besties-fcrepo-clone

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -504,6 +504,16 @@ nginx:
         default 1;
     }
 
+    # Lets the ActionCable websocket handshake for Hyrax's realtime
+    # notifications (/notifications/endpoint) actually upgrade instead of
+    # silently falling through to a plain HTTP request that Rails 404s --
+    # only kicks in when the client sends an Upgrade header, so it's a
+    # no-op for every other request.
+    map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     log_format loki 'host=${DOLLAR}host ip=${DOLLAR}http_x_forwarded_for remote_user=${DOLLAR}remote_user [${DOLLAR}time_local] '
                       'request="${DOLLAR}request" status=${DOLLAR}status bytes=${DOLLAR}body_bytes_sent '
                       'referer="${DOLLAR}http_referer" agent="${DOLLAR}http_user_agent" request_time=${DOLLAR}request_time upstream_response_time=${DOLLAR}upstream_response_time upstream_response_length=${DOLLAR}upstream_response_length';
@@ -598,6 +608,9 @@ nginx:
           proxy_set_header  X-Real-IP  ${DOLLAR}remote_addr;
           proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
           proxy_set_header Host ${DOLLAR}http_host;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade ${DOLLAR}http_upgrade;
+          proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
           proxy_pass http://rails_app;
         }

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -449,6 +449,7 @@ fcrepo:
     access_key: $AWS_ACCESS_KEY_ID
     secret_key: $AWS_SECRET_ACCESS_KEY
 global:
+  # Used by the nginx chart to calculate upstream rails_app
   hyraxHostName: palni-palci-knapsack-production
   # These global postgresql values are used by the fcrepo chart
   postgresql:
@@ -504,11 +505,8 @@ nginx:
         default 1;
     }
 
-    # Lets the ActionCable websocket handshake for Hyrax's realtime
-    # notifications (/notifications/endpoint) actually upgrade instead of
-    # silently falling through to a plain HTTP request that Rails 404s --
-    # only kicks in when the client sends an Upgrade header, so it's a
-    # no-op for every other request.
+    # For ActionCable websocket handshake for Hyrax's realtime
+    # notifications (/notifications/endpoint)
     map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
         default upgrade;
         ''      close;

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -509,7 +509,7 @@ nginx:
     # notifications (/notifications/endpoint)
     map ${DOLLAR}http_upgrade ${DOLLAR}connection_upgrade {
         default upgrade;
-        ''      close;
+        ''      '';
     }
 
     log_format loki 'host=${DOLLAR}host ip=${DOLLAR}http_x_forwarded_for remote_user=${DOLLAR}remote_user [${DOLLAR}time_local] '

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -580,7 +580,7 @@ nginx:
         }
 
         # serve static (compiled) assets directly if they exist (for rails production)
-        location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system)/ {
+        location ~ ^/(assets|packs|fonts|images|javascripts|stylesheets|swfs|system|uv|pdf\.js)/ {
           try_files ${DOLLAR}uri @rails;
 
           # access_log off;

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -492,9 +492,9 @@ nginx:
   service:
     type: ClusterIP
   image:
-    registry: registry.gitlab.com
-    repository: notch8/scripts/bitnami-nginx
-    tag: 1.21.5-debian-10-r4
+    registry: ghcr.io
+    repository: "$REPO_LOWER/nginx"
+    tag: "$TAG"
   serverBlock: |-
     upstream rails_app {
       server {{ .Values.global.hyraxHostName }};


### PR DESCRIPTION
## Summary

PALs staging didn't reproduce production's nginx bug at all (no nginx pod), so this fixes it in stages, validated with a real before/after load test ([pals-stress-tests](https://github.com/notch8/pals-stress-tests)):

- **`/system/*`**: enable nginx and mount the uploads PVC's `public-system` subPath, so branding uploads are served directly instead of proxied to Puma.
- **CPU**: bump the web pod's request/limit per real right-sizing data + observed throttling (~29-38% of periods) at the old limit.
- **`/assets/*`**: a separate, higher-volume gap — compiled assets are baked into the *web* image at build time, not on any volume nginx could see. Bakes them into a dedicated `hyku-nginx` image stage instead, matching HykuUp's existing pattern.
- **Websocket**: nginx stripped `Upgrade`/`Connection` headers, silently breaking ActionCable's realtime-notifications handshake (confirmed via a live 404 before, `101 Switching Protocols` after).

Full before/after numbers, methodology, and a couple of surprising negative results (dynamic pages needed separate follow-up work) are in the [pals-stress-tests README](https://github.com/notch8/pals-stress-tests/blob/main/README.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)