### PR TITLE
Memoize Site.instance to fix N+1-style DB round-trips

### DIFF
--- a/app/models/site_decorator.rb
+++ b/app/models/site_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyku -- Site.instance uses `first_or_create`, which is never
+# memoized: every call is a fresh database round-trip. Profiling found a
+# single /catalog page load calls Site.instance ~650-680 times, almost
+# entirely through the `delegate :account, ..., to: :instance` line (the
+# ubiquitous `Site.account` accessor), not through one obvious N+1 loop.
+# Memoize per-request via RequestStore (already a transitive dependency
+# here), the same way `current_account` is already memoized in
+# ApplicationController/HykuHelper. RequestStore clears automatically at
+# each request boundary via its own Rack middleware, which lines up with
+# when Apartment re-resolves the tenant -- so there's no risk of a stale
+# Site leaking across tenants on a reused Puma thread.
+module SiteDecorator
+  def instance
+    RequestStore.store[:site_instance] ||= super
+  end
+end
+
+Site.singleton_class.prepend(SiteDecorator)

--- a/spec/models/site_decorator_spec.rb
+++ b/spec/models/site_decorator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Site.instance (upstream Hyku, hyrax-webapp/app/models/site.rb) is defined
+# as `first_or_create`, with no memoization -- every call is a fresh
+# database round-trip. Profiling a single /catalog page load found
+# Site.instance called ~650-680 times, almost entirely through the
+# `delegate :account, ..., to: :instance` line, i.e. via the ubiquitous
+# `Site.account` convenience accessor -- not through any one obvious N+1
+# loop. This decorator memoizes it per-request via RequestStore (already a
+# transitive dependency here), the same way `current_account` already is
+# in ApplicationController/HykuHelper.
+RSpec.describe Site, type: :model do
+  before { RequestStore.clear! }
+  after { RequestStore.clear! }
+
+  describe '.instance' do
+    context 'on a specific tenant' do
+      it 'only queries the database once across multiple calls in the same request' do
+        expect(Site).to receive(:first_or_create).once.and_call_original
+
+        3.times { Site.instance }
+      end
+
+      it 'returns the same object across multiple calls' do
+        first = Site.instance
+        second = Site.instance
+
+        expect(first).to equal(second)
+      end
+
+      it 'queries again after RequestStore is cleared (simulating a new request)' do
+        Site.instance
+        RequestStore.clear!
+
+        expect(Site).to receive(:first_or_create).once.and_call_original
+        Site.instance
+      end
+    end
+
+    context 'on global tenant' do
+      before do
+        allow(Account).to receive(:global_tenant?).and_return true
+      end
+
+      it 'is still a NilSite (memoization does not change the existing global-tenant branch)' do
+        expect(Site.instance).to eq(NilSite.instance)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Site.instance` (upstream Hyku, `hyrax-webapp/app/models/site.rb`) uses `first_or_create`, which is never memoized — every call is a fresh database round-trip.
- Profiling a single `/catalog` page load (see [pals-stress-tests](https://github.com/notch8/pals-stress-tests) for the full writeup) found `Site.instance` called ~650-680 times per page render, almost entirely through the `delegate :account, ..., to: :instance` line — i.e. the ubiquitous `Site.account` convenience accessor, not one obvious N+1 loop.
- Adds `app/models/site_decorator.rb` memoizing it per-request via `RequestStore` (already a transitive dependency, no new gem needed) — the same pattern already used for `current_account` in `ApplicationController`/`HykuHelper`. `RequestStore` clears automatically at each request boundary, lining up with when Apartment re-resolves the tenant, so there's no risk of a stale `Site` leaking across tenants on a reused Puma thread.
- Written as a decorator rather than editing the vendored `hyrax-webapp` submodule directly, so this can be cleanly contributed back upstream to Hyku later.

## Test plan

- [x] Added `spec/models/site_decorator_spec.rb` first — confirmed it fails against unmemoized `Site.instance` (`first_or_create` called 2x instead of 1x, different objects returned across calls) before adding the decorator.
- [x] Confirmed green after adding `site_decorator.rb`, including that the existing global-tenant (`NilSite`) branch and post-`RequestStore.clear!` behavior are both unaffected.
- [x] Verified locally via `docker compose` (removed/restored the decorator file to directly confirm the red→green transition, not just trust the diff).
- [x] Deployed to staging and confirmed live: total SQL query count for one `/catalog` render dropped from ~1510 to 249 (~84%), the two dominant query patterns from the profiling are completely gone.
- [x] Re-ran the same tuned stress-test load before/after this fix on staging: query count dropped as expected, but overall page wall-time was flat to very slightly worse (14.8s vs 13.8s p50 on catalog) — the database round-trip was already cheap thanks to Rails' query cache, so this fix removes real, measurable overhead but isn't *the* fix for the page's overall slowness. Full writeup in the [pals-stress-tests README](https://github.com/notch8/pals-stress-tests/blob/main/README.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)