### PR TITLE
Add annotation for websocket-services to ingress

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -63,6 +63,7 @@ ingress:
           pathType: ImplementationSpecific
   annotations:
     nginx.org/client-max-body-size: "0"
+    nginx.org/websocket-services: "palni-palci-knapsack-friends-nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-production-dns"
   tls:
     - hosts:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -57,6 +57,7 @@ ingress:
           pathType: ImplementationSpecific
   annotations: {
     nginx.org/client-max-body-size: "0",
+    nginx.org/websocket-services: "palni-palci-knapsack-production-nginx",
     cert-manager.io/cluster-issuer: letsencrypt-production-dns
   }
   tls:


### PR DESCRIPTION
The notifications want to update the websocket, so they're not hitting the Puma server and taking up its threads, but they have to get all the way from the browser to the Rails app to do that.

The new ingress was blocking all websocket upgrades for security, so this allow-lists it for the specific application reverse proxies.

Deployed to https://palni-palci-knapsack-friends.notch8.cloud 

To validate the fix log in to https://demo.palni-palci-knapsack-friends.notch8.cloud and open the network tab. Previously you would see a request to a `notifications` endpoint every couple seconds that would receive a 404. You should now just not see them now because they've been switched over to a different communication mechanism.