### PR TITLE
Add extra volume mounts to prod nginx

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -496,6 +496,14 @@ nginx:
     registry: ghcr.io
     repository: "$REPO_LOWER/nginx"
     tag: "$TAG"
+  extraVolumes:
+    - name: uploads
+      persistentVolumeClaim:
+        claimName: "{{ .Values.global.hyraxHostName }}-uploads"
+  extraVolumeMounts:
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/system
+      subPath: public-system
   serverBlock: |-
     upstream rails_app {
       server {{ .Values.global.hyraxHostName }};


### PR DESCRIPTION
# Story
In order for the nginx reverse proxy to serve static assets, we need it to have access to them. Some are on mounts, so they need to be included on the nginx deploy as well as the Rails deploy. This matches the changes on the friends deployment.

Refs https://github.com/notch8/dev-ops/issues/1406

# Expected Behavior Before Changes
Assets on the public/system path are served by Rails, taking up Puma threads

# Expected Behavior After Changes
Assets on the public/system path are served by Nginx, freeing the Rails process to work on dynamic page rendering.

# Notes
Difficult to see on r2-friends environments right now because of the database issues, but verified prior to the database issues.