### PR TITLE
Increase proxy connect, send, and read timeouts for nginx

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -637,6 +637,9 @@ nginx:
           proxy_set_header Upgrade ${DOLLAR}http_upgrade;
           proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
+          proxy_connect_timeout 3600s;
+          proxy_send_timeout 3600s;
+          proxy_read_timeout 3600s;
           proxy_pass http://rails_app;
         }
     }

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -619,6 +619,9 @@ nginx:
           proxy_set_header Upgrade ${DOLLAR}http_upgrade;
           proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
+          proxy_connect_timeout 3600s;
+          proxy_send_timeout 3600s;
+          proxy_read_timeout 3600s;
           proxy_pass http://rails_app;
         }
     }


### PR DESCRIPTION
Slow client connections were timing out while sending large 10MB chunks of files

Connected to https://notch8.slack.com/archives/C088B7HJJ1E/p1786468194781399 