### PR TITLE
Scope long nginx proxy timeouts to large-transfer paths only

### DIFF
--- a/ops/friends-deploy.tmpl.yaml
+++ b/ops/friends-deploy.tmpl.yaml
@@ -624,6 +624,29 @@ nginx:
           break;
         }
 
+        # Large request/response bodies live here: chunked file uploads
+        # (/uploads), single-file and single-use-link downloads
+        # (/downloads, /single_use_link), and Bulkrax bulk import/export
+        # (/importers, /exporters -- the classic importer form posts an
+        # unchunked file directly, and exporters/:id/download streams a
+        # zip of the whole export). These get a long proxy timeout so a
+        # slow client transferring a lot of data doesn't get killed
+        # mid-request; everything else stays on @rails' short default so
+        # a genuinely hung backend request still fails fast.
+        location ~ ^/(uploads|downloads|importers|exporters|single_use_link)(/|${DOLLAR}) {
+          proxy_set_header  X-Real-IP  ${DOLLAR}remote_addr;
+          proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+          proxy_set_header Host ${DOLLAR}http_host;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade ${DOLLAR}http_upgrade;
+          proxy_set_header Connection ${DOLLAR}connection_upgrade;
+          proxy_redirect off;
+          proxy_connect_timeout 3600s;
+          proxy_send_timeout 3600s;
+          proxy_read_timeout 3600s;
+          proxy_pass http://rails_app;
+        }
+
         # send non-static file requests to the app server
         location / {
           try_files ${DOLLAR}uri @rails;
@@ -637,9 +660,6 @@ nginx:
           proxy_set_header Upgrade ${DOLLAR}http_upgrade;
           proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
-          proxy_connect_timeout 3600s;
-          proxy_send_timeout 3600s;
-          proxy_read_timeout 3600s;
           proxy_pass http://rails_app;
         }
     }

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -606,6 +606,29 @@ nginx:
           break;
         }
 
+        # Large request/response bodies live here: chunked file uploads
+        # (/uploads), single-file and single-use-link downloads
+        # (/downloads, /single_use_link), and Bulkrax bulk import/export
+        # (/importers, /exporters -- the classic importer form posts an
+        # unchunked file directly, and exporters/:id/download streams a
+        # zip of the whole export). These get a long proxy timeout so a
+        # slow client transferring a lot of data doesn't get killed
+        # mid-request; everything else stays on @rails' short default so
+        # a genuinely hung backend request still fails fast.
+        location ~ ^/(uploads|downloads|importers|exporters|single_use_link)(/|${DOLLAR}) {
+          proxy_set_header  X-Real-IP  ${DOLLAR}remote_addr;
+          proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+          proxy_set_header Host ${DOLLAR}http_host;
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade ${DOLLAR}http_upgrade;
+          proxy_set_header Connection ${DOLLAR}connection_upgrade;
+          proxy_redirect off;
+          proxy_connect_timeout 3600s;
+          proxy_send_timeout 3600s;
+          proxy_read_timeout 3600s;
+          proxy_pass http://rails_app;
+        }
+
         # send non-static file requests to the app server
         location / {
           try_files ${DOLLAR}uri @rails;
@@ -619,9 +642,6 @@ nginx:
           proxy_set_header Upgrade ${DOLLAR}http_upgrade;
           proxy_set_header Connection ${DOLLAR}connection_upgrade;
           proxy_redirect off;
-          proxy_connect_timeout 3600s;
-          proxy_send_timeout 3600s;
-          proxy_read_timeout 3600s;
           proxy_pass http://rails_app;
         }
     }


### PR DESCRIPTION
The 3600s proxy timeout added for slow upload chunks was applied blanket to @rails, the fallback for every dynamic request. That let a genuinely hung backend request (e.g. a Solr/DB stall) hang for up to an hour instead of failing fast at nginx's 60s default, tying up connections and Puma's small thread pool for far longer than before.

Split it: @rails keeps the 60s default, and a new location matches only /uploads, /downloads, /importers, /exporters, and /single_use_link -- the paths that actually carry large request or response bodies (chunked uploads, file downloads, Bulkrax bulk import/export, and shareable-link file downloads) -- and gets the 3600s timeout instead.